### PR TITLE
Change require rspec to rspec/core to avoid require error

### DIFF
--- a/lib/rspec/sleep_study.rb
+++ b/lib/rspec/sleep_study.rb
@@ -1,4 +1,4 @@
-require "rspec"
+require "rspec/core"
 
 module RSpec
   class SleepStudy

--- a/rspec-sleep_study.gemspec
+++ b/rspec-sleep_study.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "rspec-sleep_study"
-  s.version     = "1.1.0"
+  s.version     = "1.1.1"
   s.summary     = "An RSpec profiler that shows you how long specs are spending in `sleep`"
   s.author      = "Joey Schoblaska / Kenna Security"
   s.homepage    = "https://github.com/kennasecurity/rspec-sleep_study"


### PR DESCRIPTION
Sometimes `require "rspec"` throws an error when using rspec-rails, changing requirement to `require "rspec/core"` fixes this when only the core is needed.